### PR TITLE
Manually relocate `.dylibs` for OSX installation

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,6 @@ libgfortran_path = filter(x -> endswith(x, "libgfortran.3.dylib"), Libdl.dllist(
 libpath47julia = library_dependency("libpath47julia")
 libpath47_dylib = joinpath(deps_dir, "pathlib-master", "lib", "osx", "libpath47.dylib")
 libpath47julia_dylib = joinpath(deps_dir, "PathJulia-0.0.2", "lib", "osx", "libpath47julia.dylib")
-libgfortran_dylib = joinpath(deps_dir, "PathJulia-0.0.2", "lib", "osx", "libgfortran.3.dylib")
 
 pathlib_url = "https://github.com/ampl/pathlib/archive/master.zip"
 pathjulia_url = "https://github.com/chkwon/PathJulia/archive/0.0.2.tar.gz"
@@ -28,7 +27,6 @@ provides(BuildProcess,
             FileDownloader(pathjulia_url, joinpath(deps_dir, "downloads", "pathjulia.tar.gz"))
             FileUnpacker(joinpath(deps_dir, "downloads", "pathjulia.tar.gz"), deps_dir, libpath47julia_dylib)
             `cp $libpath47julia_dylib $lib_dir`
-            `cp $libgfortran_dylib $lib_dir`
             @osx_only `install_name_tool -change /usr/local/lib/libgfortran.3.dylib @rpath/libgfortran.3.dylib $lib_dir/libpath47.dylib`
             @osx_only `install_name_tool -change /usr/local/lib/libgcc_s.1.dylib @rpath/libgcc_s.1.dylib $lib_dir/libpath47.dylib`
             @osx_only `install_name_tool -add_rpath $(dirname(libgfortran_path)) $lib_dir/libpath47.dylib`

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,14 +4,7 @@ using BinDeps
 dl_dir = joinpath(dirname(dirname(@__FILE__)), "deps", "downloads")
 deps_dir = joinpath(dirname(dirname(@__FILE__)), "deps")
 lib_dir = joinpath(deps_dir, "usr", "lib")
-
-# # Check the dependency of libgfortran (should be available from the Julia installation)
-# libgfortran = library_dependency("libgfortran", aliases=["libgfortran", "libgfortran.3"])
-# libgfortran_dylib = ""
-# for (k,v) in BinDeps._find_library(libgfortran)
-#     libgfortran_dylib = v
-#     println(libgfortran_dylib)
-# end
+libgfortran_path = filter(x -> endswith(x, "libgfortran.3.dylib"), Libdl.dllist())[1]
 
 
 # The main dependency
@@ -36,6 +29,11 @@ provides(BuildProcess,
             FileUnpacker(joinpath(deps_dir, "downloads", "pathjulia.tar.gz"), deps_dir, libpath47julia_dylib)
             `cp $libpath47julia_dylib $lib_dir`
             `cp $libgfortran_dylib $lib_dir`
+            @osx_only `install_name_tool -change /usr/local/lib/libgfortran.3.dylib @rpath/libgfortran.3.dylib $lib_dir/libpath47.dylib`
+            @osx_only `install_name_tool -change /usr/local/lib/libgcc_s.1.dylib @rpath/libgcc_s.1.dylib $lib_dir/libpath47.dylib`
+            @osx_only `install_name_tool -add_rpath $(dirname(libgfortran_path)) $lib_dir/libpath47.dylib`
+            @osx_only `install_name_tool -change libpath47.dylib @rpath/libpath47.dylib $lib_dir/libpath47julia.dylib`
+            @osx_only `install_name_tool -add_rpath $lib_dir $lib_dir/libpath47julia.dylib`
         end
     end), libpath47julia, os = :Darwin)
 


### PR DESCRIPTION
This adds some BinDeps steps to manually relocate the OSX libraries to fit into wherever they are being installed.  Note that some of these steps can be done by you beforehand, e.g. you could change the dependency paths to `@rpath/` instead of `/usr/local/lib/` manually, then host those modified binaries.  The final step, adding to the `rpath` for each binary image can't be skipped however, as that change is custom to each user's machine.
