### PR TITLE
A few minor cleanups

### DIFF
--- a/src/PATHSolver.jl
+++ b/src/PATHSolver.jl
@@ -15,37 +15,12 @@ export solveMCP, options
 
 
 
-
-function solveMCP(f_eval::Function, lb::Vector, ub::Vector)
-  var_name = C_NULL
-  con_name = C_NULL
-  return solveMCP(f_eval, lb, ub, var_name, con_name)
-end
-
-function solveMCP(f_eval::Function, lb::Vector, ub::Vector, var_name)
-  con_name = C_NULL
-  return solveMCP(f_eval, lb, ub, var_name, con_name)
-end
-
-function solveMCP(f_eval::Function, lb::Vector, ub::Vector, var_name, con_name)
+function solveMCP(f_eval::Function, lb::Vector, ub::Vector, var_name=C_NULL, con_name=C_NULL)
   j_eval = x -> ForwardDiff.jacobian(f_eval, x)
   return solveMCP(f_eval, j_eval, lb, ub, var_name, con_name)
 end
 
-function solveMCP(f_eval::Function, j_eval::Function, lb::Vector, ub::Vector)
-  var_name = C_NULL
-  con_name = C_NULL
-  return solveMCP(f_eval, j_eval, lb, ub, var_name, con_name)
-end
-
-function solveMCP(f_eval::Function, j_eval::Function, lb::Vector, ub::Vector, var_name)
-  con_name = C_NULL
-  return solveMCP(f_eval, j_eval, lb, ub, var_name, con_name)
-end
-
-
-
-function solveMCP(f_eval::Function, j_eval::Function, lb::Vector, ub::Vector, var_name, con_name)
+function solveMCP(f_eval::Function, j_eval::Function, lb::Vector, ub::Vector, var_name=C_NULL, con_name=C_NULL)
   global user_f = f_eval
   global user_j = j_eval
 


### PR DESCRIPTION
Thanks for making this available! I'm playing around with connecting PATH to https://github.com/rdeits/ConditionalJuMP.jl and noticed some opportunities to clean up the code a bit. This PR does two things:

1. get rid of the redundant `solveLCP` methods without `var_name` and `con_name` arguments and replace them with default values. Default argument values in Julia do *exactly* what you were doing by hand here, so there's no reason to write out the other methods. 
2. get rid of the global `user_f` and `user_j` functions. You can call `cfunction` on a closure with no issues, so we can create a custom cfunction for the user's particular callback. 

Currently I haven't observed (2) making any performance difference, but I'm planning to build further on that change to solve LCPs (without calling ForwardDiff.jacobian at every iteration). 