### PR TITLE
variable_name, constraint_name in solve_mcp

### DIFF
--- a/src/C_API.jl
+++ b/src/C_API.jl
@@ -111,6 +111,8 @@ mutable struct InterfaceData
     lb::Vector{Cdouble}
     ub::Vector{Cdouble}
     z::Vector{Cdouble}
+    variable_name::Vector{String}
+    constraint_name::Vector{String}
 end
 
 function _c_problem_size(
@@ -182,6 +184,32 @@ function _c_jacobian_evaluation(
     return err
 end
 
+function _c_variable_name(id_ptr::Ptr{Cvoid}, variable_idx::Cint, buffer::Ptr{Cuchar}, buf_size::Cint)
+    id_data = unsafe_pointer_to_objref(id_ptr)::InterfaceData
+    str = id_data.variable_name[variable_idx]
+    # mimicking `strncpy` of Clang
+    if length(str) < buf_size
+        str *= "\0" ^ (buf_size-length(str))
+    end
+    str = str[1:buf_size] * "\0"
+    unsafe_copyto!(buffer, pointer(str), length(str))
+    return
+end
+
+function _c_constraint_name(id_ptr::Ptr{Cvoid}, constr_idx::Cint, buffer::Ptr{Cuchar}, buf_size::Cint)
+    id_data = unsafe_pointer_to_objref(id_ptr)::InterfaceData
+    str = id_data.constraint_name[constr_idx]
+    # mimicking `strncpy` of Clang
+    if length(str) < buf_size
+        str *= "\0" ^ (buf_size-length(str))
+    end
+    str = str[1:buf_size] * "\0"
+    unsafe_copyto!(buffer, pointer(str), length(str))
+    return
+end
+
+
+
 """
     MCP_Interface
 
@@ -230,6 +258,24 @@ mutable struct MCP_Interface
                 Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}
             )
         )
+        if isempty(interface_data.variable_name)
+            _C_VARIABLE_NAME = C_NULL
+        else
+            _C_VARIABLE_NAME = @cfunction(
+                _c_variable_name,
+                Cvoid,
+                (Ptr{Cvoid}, Cint, Ptr{Cuchar}, Cint)
+            )
+        end
+        if isempty(interface_data.constraint_name)
+            _C_CONSTRAINT_NAME = C_NULL
+        else
+            _C_CONSTRAINT_NAME = @cfunction(
+                _c_constraint_name,
+                Cvoid,
+                (Ptr{Cvoid}, Cint, Ptr{Cuchar}, Cint)
+            )      
+        end            
 
         return new(
             pointer_from_objref(interface_data),
@@ -240,8 +286,8 @@ mutable struct MCP_Interface
             C_NULL,
             C_NULL,  # See TODO note in definition of fields above.
             C_NULL,
-            C_NULL,
-            C_NULL,
+            _C_VARIABLE_NAME,
+            _C_CONSTRAINT_NAME,
             C_NULL
         )
     end
@@ -423,6 +469,8 @@ end
         ub::Vector{Cdouble},
         z::Vector{Cdouble};
         nnz::Int = length(lb)^2,
+        variable_name::Vector{String}=String[],
+        constraint_name::Vector{String}=String[],        
         silent::Bool = false,
         kwargs...
     )
@@ -449,6 +497,8 @@ function solve_mcp(
     ub::Vector{Cdouble},
     z::Vector{Cdouble};
     nnz::Int = length(lb)^2,
+    variable_name::Vector{String}=String[],
+    constraint_name::Vector{String}=String[],
     silent::Bool = false,
     kwargs...
 )
@@ -481,7 +531,7 @@ function solve_mcp(
     c_api_Path_AddOptions(o)
     c_api_Options_Default(o)
     m = c_api_MCP_Create(n, nnz)
-    m.id_data = InterfaceData(Cint(n), Cint(nnz), F, J, lb, ub, z)
+    m.id_data = InterfaceData(Cint(n), Cint(nnz), F, J, lb, ub, z, variable_name, constraint_name)
     m_interface = MCP_Interface(m.id_data)
     c_api_MCP_SetInterface(m, m_interface)
     if length(kwargs) > 0
@@ -552,11 +602,11 @@ end
 
 """
     solve_mcp(;
-        M::SparseArrays.CompressedSparseMatrixCSC{Cdouble, Cint},
+        M::SparseArrays.SparseMatrixCSC{Cdouble, Cint},
         q::Vector{Cdouble},
         lb::Vector{Cdouble},
         ub::Vector{Cdouble},
-        z::Vector{Cdouble};
+        z::Vector{Cdouble};    
         kwargs...
     )
 
@@ -577,8 +627,7 @@ function solve_mcp(
     q::Vector{Cdouble},
     lb::Vector{Cdouble},
     ub::Vector{Cdouble},
-    z::Vector{Cdouble};
-    silent::Bool = false,
+    z::Vector{Cdouble};  
     kwargs...
 )
     return solve_mcp(
@@ -588,7 +637,6 @@ function solve_mcp(
         ub,
         z;
         nnz = SparseArrays.nnz(M),
-        silent = silent,
         kwargs...
     )
 end

--- a/test/C_API.jl
+++ b/test/C_API.jl
@@ -122,3 +122,44 @@ end
     @test status == PATHSolver.MCP_Solved
     @test isapprox(z, [1.28475, 0.972916, 0.909376, 1.17304], atol=1e-4)
 end
+
+
+@testset "Name Test" begin
+    M = convert(
+        SparseArrays.SparseMatrixCSC{Cdouble, Cint},
+        SparseArrays.sparse([
+            0  0 -1 -1;
+            0  0  1 -2;
+            1 -1  2 -2;
+            1  2 -2  4
+        ])
+    )
+
+    z0 = [-10.0, 10.0, -5.0, 5.0]
+
+    status, z, info = PATHSolver.solve_mcp(
+        M,
+        Float64[2, 2, -2, -6],
+        fill(0.0, 4),
+        fill(10.0, 4),
+        z0;
+        variable_name = ["x1", "x2", "x3", "x4"],
+        constraint_name = ["F1", "F2", "F3", "F4"],        
+        output = "yes",
+    )
+    @test status == PATHSolver.MCP_Solved
+    @test isapprox(z, [2.8, 0.0, 0.8, 1.2])
+
+    status, z, info = PATHSolver.solve_mcp(
+        M,
+        Float64[2, 2, -2, -6],
+        fill(0.0, 4),
+        fill(10.0, 4),
+        z0;
+        variable_name = ["x1", "x2", "x3", "x4"],
+        constraint_name = ["F_VeryVeryLong_NAME_1", "F_VeryVeryLong_NAME_2", "F_VeryVeryLong_NAME_3", "F_VeryVeryLong_NAME_4"],      
+        output = "yes",
+    )
+    @test status == PATHSolver.MCP_Solved
+    @test isapprox(z, [2.8, 0.0, 0.8, 1.2])    
+end

--- a/test/C_API.jl
+++ b/test/C_API.jl
@@ -28,7 +28,7 @@ end
         fill(0.0, 4),
         fill(10.0, 4),
         [0.0, 0.0, 0.0, 0.0];
-        output = "no",
+        output = "yes",
     )
     @test status == PATHSolver.MCP_Solved
     @test isapprox(z, [2.8, 0.0, 0.8, 1.2])
@@ -143,8 +143,8 @@ end
         fill(0.0, 4),
         fill(10.0, 4),
         z0;
-        variable_name = ["x1", "x2", "x3", "x4"],
-        constraint_name = ["F1", "F2", "F3", "F4"],        
+        variable_names = ["x1", "x2", "x3", "x4"],
+        constraint_names = ["F1", "F2", "F3", "F4"],        
         output = "yes",
     )
     @test status == PATHSolver.MCP_Solved
@@ -156,10 +156,23 @@ end
         fill(0.0, 4),
         fill(10.0, 4),
         z0;
-        variable_name = ["x1", "x2", "x3", "x4"],
-        constraint_name = ["F_VeryVeryLong_NAME_1", "F_VeryVeryLong_NAME_2", "F_VeryVeryLong_NAME_3", "F_VeryVeryLong_NAME_4"],      
+        variable_names = ["x1", "x2", "x3", "x4"],
+        constraint_names = ["A2345678901234567890", "B23456789012345678901234567", "C234567890", "D234567890"],      
         output = "yes",
     )
     @test status == PATHSolver.MCP_Solved
     @test isapprox(z, [2.8, 0.0, 0.8, 1.2])    
+
+    status, z, info = PATHSolver.solve_mcp(
+        M,
+        Float64[2, 2, -2, -6],
+        fill(0.0, 4),
+        fill(10.0, 4),
+        z0;
+        variable_names = ["x1", "x2", "x3", "x4"],
+        constraint_names = ["A2345678901234567890", "B23456789012345678901234567", "C🤖λ⚽️⚽️⚽️⚽️🏸⚽️⚽️⚽️⚽️🏸", "D도레미파솔"],      
+        output = "yes",
+    )
+    @test status == PATHSolver.MCP_Solved
+    @test isapprox(z, [2.8, 0.0, 0.8, 1.2])     
 end


### PR DESCRIPTION
Supporting `variable_name` and `constraint_name` for output in `PATH`. 

```Julia
function solve_mcp(
    F::Function,
    J::Function,
    lb::Vector{Cdouble},
    ub::Vector{Cdouble},
    z::Vector{Cdouble};
    nnz::Int = length(lb)^2,
    variable_name::Vector{String}=String[],
    constraint_name::Vector{String}=String[],
    silent::Bool = false,
    kwargs...
)
```

Not sure how this can be handled in MOI.  