### PR TITLE
Fix models with no VariablePrimalStart set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PATHSolver"
 uuid = "f5f7c340-0bb3-5c69-969a-41884d311d1b"
 authors = ["Changhyun Kwon <chkwon@gmail.com>", "Oscar Dowson <o.dowson@gmail.com>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -204,6 +204,8 @@ function _F_linear_operator(model::Optimizer)
     return M, q
 end
 
+_finite(x, y) = isfinite(x) ? x : y
+
 function _bounds_and_starting(model::Optimizer)
     x = MOI.get(model, MOI.ListOfVariableIndices())
     lower = fill(-INFINITY, length(x))
@@ -214,7 +216,7 @@ function _bounds_and_starting(model::Optimizer)
         z = MOI.get(model, MOI.VariablePrimalStart(), xi)
         lower[i] = l
         upper[i] = u
-        initial[i] = z !== nothing ? z : 0.5 * (l + u)
+        initial[i] = something(z, _finite(l, _finite(u, 0.0)))
     end
     return lower, upper, initial
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -192,7 +192,7 @@ function test_variable_in_multiple_constraints()
     return
 end
 
-function _test_Example_I(; use_primal_start::Bool)
+function _test_Example_I(use_primal_start::Bool)
     model = PATHSolver.Optimizer()
     MOI.set(model, MOI.RawOptimizerAttribute("time_limit"), 60)
     @test MOI.supports(model, MOI.Silent()) == true

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -192,7 +192,7 @@ function test_variable_in_multiple_constraints()
     return
 end
 
-function test_Example_I()
+function _test_Example_I(; use_primal_start::Bool)
     model = PATHSolver.Optimizer()
     MOI.set(model, MOI.RawOptimizerAttribute("time_limit"), 60)
     @test MOI.supports(model, MOI.Silent()) == true
@@ -203,7 +203,9 @@ function test_Example_I()
     @test MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
     @test MOI.get(model, MOI.VariablePrimalStart(), x[1]) === nothing
     MOI.add_constraint.(model, x, MOI.Interval(0.0, 10.0))
-    MOI.set.(model, MOI.VariablePrimalStart(), x, 0.0)
+    if use_primal_start
+        MOI.set.(model, MOI.VariablePrimalStart(), x, 0.0)
+    end
     M = Float64[
         0 0 -1 -1
         0 0 1 -2
@@ -239,6 +241,10 @@ function test_Example_I()
     @test 0 <= MOI.get(model, MOI.SolveTimeSec()) < 1
     return
 end
+
+test_Example_I() = _test_Example_I(true)
+
+test_Example_I_no_start() = _test_Example_I(false)
 
 # An implementation of the GAMS model transmcp.gms: transporation model
 # as an equilibrium problem.


### PR DESCRIPTION
Closes #80

It's a double whammy. There was a bug if no start values are given (we'd pick `Inf`), but we also told PATH the problem was linear and that it could evaluate the Jacobian once. But evaluating the Jacobian at `Inf` caused it to terminate. I guess before it was trying to check another point because it didn't know that the Jacobian was constant.