### PR TITLE
Add support for MOI.UserDefinedFunction

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -73,6 +73,7 @@ function Optimizer()
     model.ext[:silent] = false
     model.ext[:kwargs] = Dict{Symbol,Any}()
     model.ext[:solution] = nothing
+    model.ext[:user_defined_functions] = Dict{Symbol,Any}()
     return model
 end
 
@@ -142,6 +143,19 @@ function MOI.set(
     else
         initial[x] = value
     end
+    return
+end
+
+# MOI.UserDefinedFunction
+
+MOI.supports(::Optimizer, ::MOI.UserDefinedFunction) = true
+
+function MOI.get(model::Optimizer, attr::MOI.UserDefinedFunction)
+    return model.ext[:user_defined_functions][attr.name][2]
+end
+
+function MOI.set(model::Optimizer, attr::MOI.UserDefinedFunction, value)
+    model.ext[:user_defined_functions][attr.name] = (attr.arity, value)
     return
 end
 
@@ -268,6 +282,9 @@ function _F_nonlinear_operator(model::Optimizer)
         end
     end
     nlp = MOI.Nonlinear.Model()
+    for (op, (arity, fs)) in model.ext[:user_defined_functions]
+        MOI.Nonlinear.register_operator(nlp, op, arity, fs...)
+    end
     for fi in f_map
         MOI.Nonlinear.add_constraint(nlp, fi, MOI.EqualTo(0.0))
     end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -442,7 +442,7 @@ function test_user_defined_function()
         model,
         MOI.VectorNonlinearFunction([
             MOI.ScalarNonlinearFunction(:op_f, Any[x...]),
-            MOI.ScalarNonlinearFunction(:+, Any[x[1]])
+            MOI.ScalarNonlinearFunction(:+, Any[x[1]]),
         ]),
         MOI.Complements(2),
     )

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -425,6 +425,38 @@ function test_missing_rows()
     return
 end
 
+function test_user_defined_function()
+    f(x...) = (1 - x[1])
+    function ∇f(g, x...)
+        g[1] = -1
+        return
+    end
+    model = MOI.instantiate(PATHSolver.Optimizer)
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(0.0))
+    @test MOI.supports(model, MOI.UserDefinedFunction(:op_f, 2))
+    MOI.set(model, MOI.UserDefinedFunction(:op_f, 2), (f, ∇f))
+    @test MOI.get(model, MOI.UserDefinedFunction(:op_f, 2)) == (f, ∇f)
+    MOI.add_constraint(
+        model,
+        MOI.VectorNonlinearFunction([
+            MOI.ScalarNonlinearFunction(:op_f, Any[x...]),
+            MOI.ScalarNonlinearFunction(:+, Any[x[1]])
+        ]),
+        MOI.Complements(2),
+    )
+    MOI.add_constraint(
+        model,
+        MOI.Utilities.operate(vcat, Float64, 1.0 - x[2], x[2]),
+        MOI.Complements(2),
+    )
+    MOI.optimize!(model)
+    sol = MOI.get(model, MOI.VariablePrimal(), x)
+    @test all(abs.(sol .* (1 .- sol)) .< 1e-4)
+    return
+end
+
 end
 
 TestMOIWrapper.runtests()


### PR DESCRIPTION
Closes #93 

```Julia
julia> using JuMP

julia> import BitOperations

julia> import PATHSolver

julia> function possible_shock_combinations(J)
           return [BitOperations.bget(j, i) for j in 0:(2^J-1), i in 0:(J-1)]
       end
possible_shock_combinations (generic function with 1 method)

julia> function shock_probabilities(sequences, probs)
           @assert size(sequences, 2) == length(probs)
           return map(1:size(sequences, 1)) do i
               return prod(
                   s_i ? p_i : (1 - p_i) for (s_i, p_i) in zip(sequences[i, :], probs)
               )
           end
       end
shock_probabilities (generic function with 1 method)

julia> function solve_complementarity(param1, param2, shock, probs, w, i)
           model = Model(PATHSolver.Optimizer)
           @variable(model, x[1:J] >= 0, start = 0.5)
           A = 1 .- shock .* (1 - param2)
           function f(x_j, x...)
               j = round(Int, x_j)
               return sum(probs[s] * A[s, j] / sum(A[s, k] * x[k] for k in 1:J) for s in 1:2^J)
           end
           function 𝝯f(g, x_j, x...)
               j = round(Int, x_j)
               for s in 1:2^J
                   temp = -probs[s] * A[s, j] / sum(A[s, k] * x[k] for k in 1:J)^2
                   for k in 1:J
                       g[1+k] += temp * A[s, k]
                   end
               end
               return
           end
           @operator(model, op_f, 1 + J, f, 𝝯f)
           @constraint(model, c[j in 1:J], -(1 - param1) * w[i] * op_f(j, x...) + w[j] ⟂ x[j])
           optimize!(model)
           return value.(x)
       end
solve_complementarity (generic function with 1 method)

julia> begin
           J = 10
           param1 = 0.5
           param2 = 0.1
           prob = fill(0.5, J)
           shock = possible_shock_combinations(J)
           probs = shock_probabilities(shock, prob)
           w = ones(J)
           i = 1
           x = solve_complementarity(param1, param2, shock, probs, w, i)
       end
Path 5.0.03 (Fri Jun 26 09:58:07 2020)
Written by Todd Munson, Steven Dirkse, Youngdae Kim, and Michael Ferris


Crash Log
major  func  diff  size  residual    step       prox   (label)
    0     0             1.1714e+00             0.0e+00 (f[    1])
    1     2     0    10 2.8492e-01  8.0e-01    0.0e+00 (f[    5])
pn_search terminated: no basis change.

Major Iteration Log
major minor  func  grad  residual    step  type prox    inorm  (label)
    0     0     3     2 2.8492e-01           I 0.0e+00 9.0e-02 (f[    5])
    1     1     7     3 9.6246e-02  5.1e-01 SB 0.0e+00 3.0e-02 (f[   10])
    2     1     8     4 1.8330e-03  1.0e+00 SO 0.0e+00 5.8e-04 (f[    1])
    3     1     9     5 1.0492e-06  1.0e+00 SO 0.0e+00 3.3e-07 (f[   10])
    4     1    10     6 3.7354e-13  1.0e+00 SO 0.0e+00 1.2e-13 (f[    1])

Major Iterations. . . . 4
Minor Iterations. . . . 4
Restarts. . . . . . . . 0
Crash Iterations. . . . 1
Gradient Steps. . . . . 0
Function Evaluations. . 10
Gradient Evaluations. . 6
Basis Time. . . . . . . 0.000101
Total Time. . . . . . . 0.545882
Residual. . . . . . . . 3.735389e-13
10-element Vector{Float64}:
 0.049999999999993314
 0.04999999999999365
 0.049999999999993494
 0.049999999999993695
 0.04999999999999393
 0.049999999999993786
 0.04999999999999392
 0.0499999999999937
 0.049999999999993494
 0.05000000000000107
```