### PR TITLE
Check license to avoid silent failures

### DIFF
--- a/src/C_API.jl
+++ b/src/C_API.jl
@@ -748,8 +748,13 @@ function solve_mcp(
     jacobian_structure_constant::Bool = false,
     jacobian_data_contiguous::Bool = false,
     jacobian_linear_elements::Vector{Int} = Int[],
+    check_license::Bool = true,
     kwargs...,
 )
+    if check_license && iszero(c_api_Path_CheckLicense(length(z), nnz))
+        return MCP_LicenseError, nothing, nothing
+    end
+
     @assert length(z) == length(lb) == length(ub)
     out_io = silent ? IOBuffer() : stdout
     output_data = OutputData(out_io)

--- a/src/C_API.jl
+++ b/src/C_API.jl
@@ -748,13 +748,11 @@ function solve_mcp(
     jacobian_structure_constant::Bool = false,
     jacobian_data_contiguous::Bool = false,
     jacobian_linear_elements::Vector{Int} = Int[],
-    check_license::Bool = true,
     kwargs...,
 )
-    if check_license && iszero(c_api_Path_CheckLicense(length(z), nnz))
+    if c_api_Path_CheckLicense(length(z), nnz) == 0
         return MCP_LicenseError, nothing, nothing
     end
-
     @assert length(z) == length(lb) == length(ub)
     out_io = silent ? IOBuffer() : stdout
     output_data = OutputData(out_io)

--- a/test/C_API.jl
+++ b/test/C_API.jl
@@ -31,6 +31,15 @@ end
 function test_CheckLicense()
     @test PATHSolver.c_api_License_SetString("bad_license") != 0
     @test PATHSolver.c_api_Path_CheckLicense(1, 1) > 0
+    @test let n = 100
+        PATHSolver.solve_mcp(
+            SparseArrays.SparseMatrixCSC{Float64,Int32}(rand(n, n)),
+            rand(n),
+            rand(n),
+            rand(n),
+            rand(n),
+        ) == (PATHSolver.MCP_LicenseError, nothing, nothing)
+    end
     return
 end
 


### PR DESCRIPTION
When the user hands in a problem that is larger than their license allows, `solve_mcp` currently just silently gives a wrong result. This PR adds a license check to the `solve_mcp` C_API function. The overhead of the check is only about 20ns on my machine so I think this is worth it.