### PR TITLE
Forward user interrupts

### DIFF
--- a/src/C_API.jl
+++ b/src/C_API.jl
@@ -820,6 +820,11 @@ function solve_mcp(
         )
         status = c_api_Path_Solve(m, info)
     end  # GC.@preserve
+
+    if status == MCP_UserInterrupt
+        throw(InterruptException())
+    end
+
     X = c_api_MCP_GetX(m)
     # TODO(odow): I don't know why, but manually calling MCP_Destroy was
     # necessary to avoid a segfault on Julia 1.0 when using LUSOL. I guess it's


### PR DESCRIPTION
Currently, when running PATH in a for-loop, one cannot really interrupt the program reliably. The reason for this is that the `ctrl+c` will often just be caught by PATH (in C) but the interrupt is never forwarded to Julia. This PR throws an interrupt error when the status of the C call is MCP_UserInterrupt.