### PR TITLE
Fix performance issue building large sparse linear operators

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -163,7 +163,7 @@ end
 
 function _F_linear_operator(model::Optimizer)
     n = MOI.get(model, MOI.NumberOfVariables())
-    M = SparseArrays.sparse(Int32[], Int32[], Float64[], n, n)
+    I, J, V = Int32[], Int32[], Float64[]
     q = zeros(n)
     has_term = fill(false, n)
     names = fill("", n)
@@ -231,7 +231,9 @@ function _F_linear_operator(model::Optimizer)
                     "$(div(Si.dimension, 2) + term.output_index).",
                 )
             end
-            M[row_i, s_term.variable.value] += s_term.coefficient
+            push!(I, row_i)
+            push!(J, s_term.variable.value)
+            push!(V, s_term.coefficient)
         end
         c_name = MOI.get(model, MOI.ConstraintName(), index)
         if length(rows) == 2
@@ -242,6 +244,7 @@ function _F_linear_operator(model::Optimizer)
             end
         end
     end
+    M = SparseArrays.sparse(I, J, V, n, n)
     return M, q, SparseArrays.nnz(M), names
 end
 


### PR DESCRIPTION
Closes #121

I think I had just assumed that people would build lots of small rows, rather than a big single complementarity constraint.

For `n = 2048` I now get:
```julia
julia> @constraint(model, M * x .+ q ⟂ x)
[x[1] - 1, 2 x[1] + x[2] - 1, 2 x[1] + 2 x[2] + x[3] - 1, 2 x[1] + 2 x[2] + 2 x[3] + x[4] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + x[5] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + x[6] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + x[7] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + x[8] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + 2 x[8] + x[9] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + 2 x[8] + 2 x[9] + x[10] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + 2 x[8] + 2 x[9] + 2 x[10] + x[11] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + 2 x[8] + 2 x[9] + 2 x[10] + 2 x[11] + x[12] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + 2 x[8] + 2 x[9] + 2 x[10] + 2 x[11] + 2 x[12] + x[13] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + 2 x[8] + 2 x[9] + 2 x[10] + 2 x[11] + 2 x[12] + 2 x[13] + x[14] - 1, 2 x[1] + 2 x[2] + 2 x[3] + 2 x[4] + 2 x[5] + 2 x[6] + 2 x[7] + 2 x[8] + 2 x[9] + 2 x[10] + 2 x[11] + 2 x[12] + 2 x[13] + 2 x[14] + x[15] - 1, [[...4066 terms omitted...]], x[2034], x[2035], x[2036], x[2037], x[2038], x[2039], x[2040], x[2041], x[2042], x[2043], x[2044], x[2045], x[2046], x[2047], x[2048]] ∈ MathOptInterface.Complements(4096)

julia> @time optimize!(model)
  0.499948 seconds (26.03 k allocations: 297.203 MiB, 46.23% gc time)
```